### PR TITLE
man page: add missing argument for the block-count option

### DIFF
--- a/par2.1
+++ b/par2.1
@@ -45,7 +45,7 @@ Show version and copyright
 .BI "\-a <" "file" ">"
 Set the main par2 archive name; required on create, optional for verify and repair
 .TP
-.B \-b
+.B \-b<n>
 Set the Block\(hyCount
 .TP
 .B \-s<n>


### PR DESCRIPTION
related debian bug is https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782980